### PR TITLE
ci: add trusted publish workflow

### DIFF
--- a/.github/workflows/trusted_publish.yml
+++ b/.github/workflows/trusted_publish.yml
@@ -1,0 +1,26 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish  # Or: npm stage publish


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/trusted_publish.yml` to enable trusted npm publishing on version tags
- Workflow triggers on `v*` tag pushes, uses OIDC for authentication, and runs build + test before publishing
- Named `trusted_publish.yml` to coexist with the existing `publish.yml`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm OIDC permissions are configured for this repo in npmjs
- [ ] Test by pushing a version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)